### PR TITLE
mdx_unimoji を1.1に、Makefileを追加等

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+tmp
+Dockerfile.backup
+Dockerfile.exclude

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM squidfunk/mkdocs-material:8.2.8
+ARG VARIANT="8.3.9"
+FROM squidfunk/mkdocs-material:${VARIANT}
 
 RUN apk add --no-cache --virtual .devel gcc make musl-dev \
  && pip install 'mdx_truly_sane_lists==1.2.*' \
-                'mdx_unimoji==1.0.*' \
+                'mdx_unimoji==1.1.*' \
                 'mkdocs-awesome-pages-plugin==2.6.*' \
                 'plantuml-markdown==3.5.*' \
                 'pymdown-extensions==9.1.*' \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+REPO_NAME	?= local
+IMAGE_NAME	= $(REPO_NAME)/mkdocs-material
+TAG		= 8.3.9
+
+help:	## Show this help.
+	@sed -ne '/@sed/!s/## //p' $(MAKEFILE_LIST)
+
+build:	## build
+	docker build \
+		-t $(IMAGE_NAME):$(TAG) \
+		-t $(IMAGE_NAME):latest \
+		--build-arg VARIANT=$(TAG) \
+		.
+
+scan:	## scan
+	docker scan $(IMAGE_NAME):$(TAG)
+
+push:	## push
+	docker push $(IMAGE_NAME):$(TAG)
+	docker push $(IMAGE_NAME):latest
+
+login:	## login docker shell
+	docker run -it --rm -v $(PWD):/docs --entrypoint /bin/sh $(IMAGE_NAME):latest
+


### PR DESCRIPTION
ビルドできなくなってたのを修正。
原因、https://github.com/kernc/mdx_unimoji/pull/3
